### PR TITLE
New session same pwd

### DIFF
--- a/app/config/behaviorsettings.ui
+++ b/app/config/behaviorsettings.ui
@@ -20,6 +20,13 @@
       <string comment="@title:group Group box label">General</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
+      <item row="7" column="0" colspan="2">
+       <widget class="QCheckBox" name="kcfg_NewSessionSamePwd">
+        <property name="text">
+         <string comment="@option:check">Open new sessions in the same directory as current session</string>
+        </property>
+       </widget>
+      </item>
       <item row="6" column="0" colspan="2">
        <widget class="QCheckBox" name="kcfg_FocusFollowsMouse">
         <property name="text">
@@ -167,6 +174,7 @@
   <tabstop>kcfg_ToggleToFocus</tabstop>
   <tabstop>kcfg_KeepOpenAfterLastSessionCloses</tabstop>
   <tabstop>kcfg_FocusFollowsMouse</tabstop>
+  <tabstop>kcfg_NewSessionSamePwd</tabstop>
   <tabstop>kcfg_ConfirmQuit</tabstop>
  </tabstops>
  <resources/>

--- a/app/config/yakuake.kcfg
+++ b/app/config/yakuake.kcfg
@@ -78,6 +78,11 @@
       <whatsthis context="@info:whatsthis">Whether the application window should be opened after program start.</whatsthis>
     <default>false</default>
     </entry>
+    <entry name="NewSessionSamePwd" type="Bool">
+      <label context="@label">Open new session in same directory</label>
+      <whatsthis context="@info:whatsthis">Whether the new session should be opened in the same directory as the current session.</whatsthis>
+      <default>true</default>
+    </entry>
   </group>
   <group name="Appearance">
     <entry name="Skin" type="String">

--- a/app/session.cpp
+++ b/app/session.cpp
@@ -19,7 +19,7 @@
   along with this program. If not, see http://www.gnu.org/licenses/.
 */
 
-
+#include "settings.h"
 #include "session.h"
 #include "terminal.h"
 
@@ -286,7 +286,7 @@ int Session::split(Terminal* terminal, Qt::Orientation orientation)
             splitter->setOrientation(orientation);
 
         // XXX: find out if terminal can be NULL here
-        terminal = addTerminal(terminal ? terminal->currentDir() : QDir::homePath(), splitter);
+        terminal = addTerminal(Settings::newSessionSamePwd() && terminal ? terminal->currentDir() : QDir::homePath(), splitter);
 
         QList<int> newSplitterSizes;
         newSplitterSizes << (splitterWidth / 2) << (splitterWidth / 2);
@@ -312,7 +312,7 @@ int Session::split(Terminal* terminal, Qt::Orientation orientation)
 
         terminal->setSplitter(newSplitter);
 
-        terminal = addTerminal(terminal->currentDir(), newSplitter);
+        terminal = addTerminal(Settings::newSessionSamePwd() ? terminal->currentDir() : QDir::homePath(), newSplitter);
 
         splitter->setSizes(splitterSizes);
         QList<int> newSplitterSizes;

--- a/app/session.cpp
+++ b/app/session.cpp
@@ -23,10 +23,11 @@
 #include "session.h"
 #include "terminal.h"
 
+#include <QDir>
 
 int Session::m_availableSessionId = 0;
 
-Session::Session(SessionType type, QWidget* parent) : QObject(parent)
+Session::Session(const QString& workingDir, SessionType type, QWidget* parent) : QObject(parent)
 {
     m_sessionId = m_availableSessionId;
     m_availableSessionId++;
@@ -38,7 +39,7 @@ Session::Session(SessionType type, QWidget* parent) : QObject(parent)
     m_baseSplitter = new Splitter(Qt::Horizontal, parent);
     connect(m_baseSplitter, SIGNAL(destroyed()), this, SLOT(prepareShutdown()));
 
-    setupSession(type);
+    setupSession(workingDir, type);
 }
 
 Session::~Session()
@@ -48,13 +49,13 @@ Session::~Session()
     emit destroyed(m_sessionId);
 }
 
-void Session::setupSession(SessionType type)
+void Session::setupSession(const QString& workingDir, SessionType type)
 {
     switch (type)
     {
         case Single:
         {
-            Terminal* terminal = addTerminal(m_baseSplitter);
+            Terminal* terminal = addTerminal(workingDir, m_baseSplitter);
             setActiveTerminal(terminal->id());
 
             break;
@@ -64,8 +65,8 @@ void Session::setupSession(SessionType type)
         {
             int splitterWidth = m_baseSplitter->width();
 
-            Terminal* terminal = addTerminal(m_baseSplitter);
-            addTerminal(m_baseSplitter);
+            Terminal* terminal = addTerminal(workingDir, m_baseSplitter);
+            addTerminal(workingDir, m_baseSplitter);
 
             QList<int> newSplitterSizes;
             newSplitterSizes << (splitterWidth / 2) << (splitterWidth / 2);
@@ -88,8 +89,8 @@ void Session::setupSession(SessionType type)
 
             int splitterHeight = m_baseSplitter->height();
 
-            Terminal* terminal = addTerminal(m_baseSplitter);
-            addTerminal(m_baseSplitter);
+            Terminal* terminal = addTerminal(workingDir, m_baseSplitter);
+            addTerminal(workingDir, m_baseSplitter);
 
             QList<int> newSplitterSizes;
             newSplitterSizes << (splitterHeight / 2) << (splitterHeight / 2);
@@ -119,11 +120,11 @@ void Session::setupSession(SessionType type)
             Splitter* lowerSplitter = new Splitter(Qt::Horizontal, m_baseSplitter);
             connect(lowerSplitter, SIGNAL(destroyed()), this, SLOT(cleanup()));
 
-            Terminal* terminal = addTerminal(upperSplitter);
-            addTerminal(upperSplitter);
+            Terminal* terminal = addTerminal(workingDir, upperSplitter);
+            addTerminal(workingDir, upperSplitter);
 
-            addTerminal(lowerSplitter);
-            addTerminal(lowerSplitter);
+            addTerminal(workingDir, lowerSplitter);
+            addTerminal(workingDir, lowerSplitter);
 
             QList<int> newSplitterSizes;
             newSplitterSizes << (splitterHeight / 2) << (splitterHeight / 2);
@@ -147,16 +148,16 @@ void Session::setupSession(SessionType type)
 
         default:
         {
-            addTerminal(m_baseSplitter);
+            addTerminal(workingDir, m_baseSplitter);
 
             break;
         }
     }
 }
 
-Terminal* Session::addTerminal(QWidget* parent)
+Terminal* Session::addTerminal(const QString& workingDir, QWidget* parent)
 {
-    Terminal* terminal = new Terminal(parent);
+    Terminal* terminal = new Terminal(workingDir, parent);
     connect(terminal, SIGNAL(activated(int)), this, SLOT(setActiveTerminal(int)));
     connect(terminal, SIGNAL(manuallyActivated(Terminal*)), this, SIGNAL(terminalManuallyActivated(Terminal*)));
     connect(terminal, SIGNAL(titleChanged(int,QString)), this, SLOT(setTitle(int,QString)));
@@ -284,7 +285,8 @@ int Session::split(Terminal* terminal, Qt::Orientation orientation)
         if (splitter->orientation() != orientation)
             splitter->setOrientation(orientation);
 
-        terminal = addTerminal(splitter);
+        // XXX: find out if terminal can be NULL here
+        terminal = addTerminal(terminal ? terminal->currentDir() : QDir::homePath(), splitter);
 
         QList<int> newSplitterSizes;
         newSplitterSizes << (splitterWidth / 2) << (splitterWidth / 2);
@@ -310,7 +312,7 @@ int Session::split(Terminal* terminal, Qt::Orientation orientation)
 
         terminal->setSplitter(newSplitter);
 
-        terminal = addTerminal(newSplitter);
+        terminal = addTerminal(terminal->currentDir(), newSplitter);
 
         splitter->setSizes(splitterSizes);
         QList<int> newSplitterSizes;

--- a/app/session.h
+++ b/app/session.h
@@ -41,7 +41,7 @@ class Session : public QObject
         enum SessionType { Single, TwoHorizontal, TwoVertical, Quad };
         enum GrowthDirection { Up, Right, Down, Left };
 
-        explicit Session(SessionType type = Single, QWidget* parent = 0);
+        explicit Session(const QString& workingDir, SessionType type = Single, QWidget* parent = 0);
          ~Session();
 
         int id() { return m_sessionId; }
@@ -118,9 +118,9 @@ class Session : public QObject
 
 
     private:
-        void setupSession(SessionType type);
+        void setupSession(const QString& workingDir, SessionType type);
 
-        Terminal* addTerminal(QWidget* parent);
+        Terminal* addTerminal(const QString& workingDir, QWidget* parent);
         int split(Terminal* terminal, Qt::Orientation orientation);
 
         static int m_availableSessionId;

--- a/app/sessionstack.cpp
+++ b/app/sessionstack.cpp
@@ -54,7 +54,7 @@ int SessionStack::addSession(Session::SessionType type)
     Session*  currentSession  = m_sessions.value(m_activeSessionId);
     Terminal* currentTerminal = currentSession ? currentSession->getTerminal(currentSession->activeTerminalId()) : NULL;
     bool ok = false;
-    QString workingDir(currentTerminal ? currentTerminal->currentDir(&ok) : QString::null);
+    QString workingDir(Settings::newSessionSamePwd() && currentTerminal ? currentTerminal->currentDir(&ok) : QString::null);
 
     if (!ok) {
         workingDir = QDir::homePath();

--- a/app/sessionstack.cpp
+++ b/app/sessionstack.cpp
@@ -51,7 +51,16 @@ SessionStack::~SessionStack()
 
 int SessionStack::addSession(Session::SessionType type)
 {
-    Session* session = new Session(type, this);
+    Session*  currentSession  = m_sessions.value(m_activeSessionId);
+    Terminal* currentTerminal = currentSession ? currentSession->getTerminal(currentSession->activeTerminalId()) : NULL;
+    bool ok = false;
+    QString workingDir(currentTerminal ? currentTerminal->currentDir(&ok) : QString::null);
+
+    if (!ok) {
+        workingDir = QDir::homePath();
+    }
+
+    Session* session = new Session(workingDir, type, this);
     connect(session, SIGNAL(titleChanged(int,QString)), this, SIGNAL(titleChanged(int,QString)));
     connect(session, SIGNAL(terminalManuallyActivated(Terminal*)), this, SLOT(handleManualTerminalActivation(Terminal*)));
     connect(session, SIGNAL(keyboardInputBlocked(Terminal*)), m_visualEventOverlay, SLOT(indicateKeyboardInputBlocked(Terminal*)));

--- a/app/terminal.cpp
+++ b/app/terminal.cpp
@@ -30,19 +30,21 @@
 #include <KPluginLoader>
 #include <KService>
 
+#include <QString>
 #include <QAction>
 #include <QApplication>
 #include <QDir>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QWidget>
+#include <QFileInfo>
 
 #include <QKeyEvent>
 
 
 int Terminal::m_availableTerminalId = 0;
 
-Terminal::Terminal(QWidget* parent) : QObject(parent)
+Terminal::Terminal(const QString& workingDir, QWidget* parent) : QObject(parent)
 {
     m_terminalId = m_availableTerminalId;
     m_availableTerminalId++;
@@ -86,7 +88,7 @@ Terminal::Terminal(QWidget* parent) : QObject(parent)
         disableOffendingPartActions();
 
         m_terminalInterface = qobject_cast<TerminalInterface*>(m_part);
-        if (m_terminalInterface) m_terminalInterface->showShellInDir(QDir::homePath());
+        if (m_terminalInterface) m_terminalInterface->showShellInDir(workingDir);
     }
     else
         displayKPartLoadError();
@@ -139,6 +141,22 @@ bool Terminal::eventFilter(QObject* /* watched */, QEvent* event)
     }
 
     return false;
+}
+
+QString Terminal::currentDir(bool *ok) const {
+    if (m_terminalInterface)
+    {
+        QFileInfo info( QStringLiteral("/proc/%1/cwd").arg(m_terminalInterface->terminalProcessId()) );
+
+        if (info.isReadable() && info.isSymLink())
+        {
+            if (ok) *ok = true;
+            return info.symLinkTarget();
+        }
+    }
+
+    if (ok) *ok = false;
+    return QString();
 }
 
 void Terminal::displayKPartLoadError()

--- a/app/terminal.h
+++ b/app/terminal.h
@@ -37,13 +37,15 @@ class Terminal : public QObject
     Q_OBJECT
 
     public:
-        explicit Terminal(QWidget* parent = 0);
+        explicit Terminal(const QString& workingDir, QWidget* parent = 0);
          ~Terminal();
 
         bool eventFilter(QObject* watched, QEvent* event) Q_DECL_OVERRIDE;
 
         int id() { return m_terminalId; }
         const QString title() { return m_title; }
+
+        QString currentDir(bool *ok = NULL) const;
 
         QWidget* partWidget() { return m_partWidget; }
         QWidget* terminalWidget() { return m_terminalWidget; }


### PR DESCRIPTION
Ability to start new sessions in the directory of the current session via `/proc/pid/cwd` (adaptation of https://github.com/panzi/Yakuake/tree/new_tab_same_pwd). Has config option that defaults to true. If false, opens new session in home directory as usual.