### PR TITLE
Open new tab in same current working directory of active tab

### DIFF
--- a/app/session.h
+++ b/app/session.h
@@ -41,11 +41,12 @@ class Session : public QObject
         enum SessionType { Single, TwoHorizontal, TwoVertical, Quad };
         enum GrowthDirection { Up, Right, Down, Left };
 
-        explicit Session(SessionType type = Single, QWidget* parent = 0);
+        explicit Session(SessionType type = Single, QString workingDirectory = QString(), QWidget* parent = 0);
          ~Session();
 
         int id() { return m_sessionId; }
         const QString title() { return m_title; }
+        const QString workingDirectory();
         QWidget* widget() { return m_baseSplitter; }
 
         int activeTerminalId() { return m_activeTerminalId; }
@@ -132,6 +133,8 @@ class Session : public QObject
         QMap<int, Terminal*> m_terminals;
 
         QString m_title;
+
+        QString m_workingDirectory;
 
         bool m_closable;
 };

--- a/app/sessionstack.cpp
+++ b/app/sessionstack.cpp
@@ -49,9 +49,23 @@ SessionStack::~SessionStack()
 {
 }
 
+const QString SessionStack::activeTerminalCurrentWorkingDirectory()
+{
+    QString q = QString();
+    if (m_activeSessionId == -1) return q;
+    if (!m_sessions.contains(m_activeSessionId)) return q;
+
+    Terminal *activeTerminal = m_sessions.value(m_activeSessionId)->getTerminal(activeTerminalId());
+    if (activeTerminal) {
+        return activeTerminal->currentWorkingDirectory();
+    }
+    return q;
+}
+
 int SessionStack::addSession(Session::SessionType type)
 {
-    Session* session = new Session(type, this);
+    QString currentWorkingDirectory = activeTerminalCurrentWorkingDirectory();
+    Session* session = new Session(type, currentWorkingDirectory, this);
     connect(session, SIGNAL(titleChanged(int,QString)), this, SIGNAL(titleChanged(int,QString)));
     connect(session, SIGNAL(terminalManuallyActivated(Terminal*)), this, SLOT(handleManualTerminalActivation(Terminal*)));
     connect(session, SIGNAL(keyboardInputBlocked(Terminal*)), m_visualEventOverlay, SLOT(indicateKeyboardInputBlocked(Terminal*)));
@@ -68,6 +82,8 @@ int SessionStack::addSession(Session::SessionType type)
         emit sessionAdded(session->id(), session->title());
     else
         emit sessionAdded(session->id(), QString());
+
+    raiseSession(session->id())
 
     return session->id();
 }

--- a/app/sessionstack.h
+++ b/app/sessionstack.h
@@ -150,6 +150,8 @@ class SessionStack : public QStackedWidget
         enum QueryCloseType { QueryCloseSession, QueryCloseTerminal };
         bool queryClose(int sessionId, QueryCloseType type);
 
+        const QString currentWorkingDirectory();
+
         VisualEventOverlay* m_visualEventOverlay;
 
         int m_activeSessionId;

--- a/app/terminal.cpp
+++ b/app/terminal.cpp
@@ -42,8 +42,12 @@
 
 int Terminal::m_availableTerminalId = 0;
 
-Terminal::Terminal(QWidget* parent) : QObject(parent)
+Terminal::Terminal(QString currentWorkingDirectory, QWidget* parent) : QObject(parent)
 {
+    if (currentWorkingDirectory.isEmpty()) {
+        currentWorkingDirectory = QDir::homePath();
+    }
+
     m_terminalId = m_availableTerminalId;
     m_availableTerminalId++;
 
@@ -86,7 +90,7 @@ Terminal::Terminal(QWidget* parent) : QObject(parent)
         disableOffendingPartActions();
 
         m_terminalInterface = qobject_cast<TerminalInterface*>(m_part);
-        if (m_terminalInterface) m_terminalInterface->showShellInDir(QDir::homePath());
+        if (m_terminalInterface) m_terminalInterface->showShellInDir(currentWorkingDirectory);
     }
     else
         displayKPartLoadError();
@@ -139,6 +143,14 @@ bool Terminal::eventFilter(QObject* /* watched */, QEvent* event)
     }
 
     return false;
+}
+
+const QString Terminal::currentWorkingDirectory()
+{
+    if (m_terminalInterface) {
+        return m_terminalInterface->currentWorkingDirectory();
+    }
+    return QString();
 }
 
 void Terminal::displayKPartLoadError()

--- a/app/terminal.h
+++ b/app/terminal.h
@@ -37,13 +37,15 @@ class Terminal : public QObject
     Q_OBJECT
 
     public:
-        explicit Terminal(QWidget* parent = 0);
+        explicit Terminal(QString currentWorkingDirectory = QString(), QWidget* parent = 0);
          ~Terminal();
 
         bool eventFilter(QObject* watched, QEvent* event) Q_DECL_OVERRIDE;
 
         int id() { return m_terminalId; }
         const QString title() { return m_title; }
+
+        const QString currentWorkingDirectory();
 
         QWidget* partWidget() { return m_partWidget; }
         QWidget* terminalWidget() { return m_terminalWidget; }


### PR DESCRIPTION
This is a work in progress. I just like to know if the approach I took makes sense.

This has been a long standing bug with Yakuake. It worked before, but some time in the transition to KDE 4, things got broken. I looked at the code and figured out why: new tabs are always started using the user's home directory.

So the whole patch is basically about being able to query the active Terminal's current working directory and passing that value to new Terminals to be created. It works for the most part (I'm using it now) but I still have to fix some bugs related to tracking the current Terminal and the current Session.