### PR TITLE
After tab renaming, refocus on the console session

### DIFF
--- a/app/tabbar.cpp
+++ b/app/tabbar.cpp
@@ -808,6 +808,7 @@ void TabBar::interactiveRenameDone()
     m_renamingSessionId = -1;
 
     setTabTitleInteractive(sessionId, m_lineEdit->text().trimmed());
+    emit tabSelected(sessionId); // put focus back on the console
 }
 
 void TabBar::selectTab(int sessionId)


### PR DESCRIPTION
Fixes the bug that after renaming a tab, you have to click the konsole session before you can type in it.