### PR TITLE
Fix behavior when set to keep open but not above

### DIFF
--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -843,13 +843,13 @@ void MainWindow::applySkin()
 
 void MainWindow::applyWindowProperties()
 {
-    if (Settings::keepOpen() && !Settings::keepAbove())
-    {
-        KWindowSystem::clearState(winId(), NET::KeepAbove);
+    if (Settings::keepOpen())
         KWindowSystem::setState(winId(), NET::Sticky | NET::SkipTaskbar | NET::SkipPager);
-    }
+
+    if (Settings::keepAbove())
+        KWindowSystem::setState(winId(), NET::KeepAbove);
     else
-        KWindowSystem::setState(winId(), NET::KeepAbove | NET::Sticky | NET::SkipTaskbar | NET::SkipPager);
+        KWindowSystem::clearState(winId(), NET::KeepAbove);
 
     KWindowSystem::setOnAllDesktops(winId(), Settings::showOnAllDesktops());
     KWindowEffects::enableBlurBehind(winId(), Settings::blur());


### PR DESCRIPTION
I'm using Yakuake 19.08.3 on Gentoo and I had the issue that once setting the window to stay open, it was also always staying above, also when setting keepAbove=false in ~/.config/yakuakerc.

This change fixes the behavior for me.