### PR TITLE
Fix maximization behaviour

### DIFF
--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -1062,18 +1062,18 @@ void MainWindow::wmActiveWindowChanged()
 
 void MainWindow::changeEvent(QEvent* event)
 {
-    if (event->type() == QEvent::WindowStateChange
-        && (windowState() & Qt::WindowMaximized)
-        && Settings::width() != 100
-        && Settings::height() != 100)
+    if (event->type() == QEvent::WindowStateChange)
     {
-        Settings::setWidth(100);
-        Settings::setHeight(100);
-
-        applyWindowGeometry();
-
-        updateWindowWidthMenu();
-        updateWindowHeightMenu();
+        if ((windowState() & Qt::WindowMaximized))
+        {
+            /* Maximization has not being saving to Settings as it seems
+             * reasonable and has simplier implementation.
+             * */
+            setWindowGeometry(100, 100, Settings::position());
+            setWindowState(Qt::WindowMaximized);
+        } else {
+            setWindowGeometry(Settings::width(), Settings::height(), Settings::position());
+        }
     }
 
     KMainWindow::changeEvent(event);

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -93,7 +93,7 @@ class MainWindow : public KMainWindow
         void paintEvent(QPaintEvent*) override;
         void moveEvent(QMoveEvent*) override;
         void changeEvent(QEvent* event) override;
-        void closeEvent(QCloseEvent *event) override;
+        void closeEvent(QCloseEvent* event) override;
         bool event(QEvent* event) override;
 
         virtual bool queryClose() override;


### PR DESCRIPTION
This commit fixes next issues:
1. Yakuake main window geometry stays maximized ([BUG: 414049](https://bugs.kde.org/show_bug.cgi?id=414049)).
1. In some states maximized geometry may come to settings file and become persistent.
1. Geometry becomes broken after size normalization.

This is a duplicate of [D28516](https://phabricator.kde.org/D28516). I am not sure where is the right place for patches. Maybe [page](https://kde.org/applications/system/org.kde.yakuake) on kde.org needs update.