### PR TITLE
Bugfix for highlight terminals when moving focus -> highlighting does not correctly disappear

### DIFF
--- a/app/visualeventoverlay.cpp
+++ b/app/visualeventoverlay.cpp
@@ -200,7 +200,7 @@ void VisualEventOverlay::hideEvent(QHideEvent *)
 
 void VisualEventOverlay::scheduleCleanup(int in)
 {
-    int left = m_cleanupTimerCeiling - m_cleanupTimerStarted.elapsed();
+    int left = (m_cleanupTimerStarted.isValid())? m_cleanupTimerCeiling - m_cleanupTimerStarted.elapsed() : 0;
 
     if (in > left) {
         m_cleanupTimerCeiling = in;


### PR DESCRIPTION
Fix for 'highlight terminals when moving focus' not disappearing bug [https://bugs.kde.org/show_bug.cgi?id=441013](https://bugs.kde.org/show_bug.cgi?id=441013)
provided by [Ebcdic](https://bugs.kde.org/show_bug.cgi?id=441013#c6)