### PR TITLE
Draft: Wayland fullscreen toggling improvements

### DIFF
--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -1400,8 +1400,8 @@ void MainWindow::sharedPreOpenWindow()
 
     if (Settings::pollMouse())
         toggleMousePoll(false);
-    if (Settings::rememberFullscreen())
-        setFullScreen(m_isFullscreen);
+    if (!Settings::rememberFullscreen())
+        setFullScreen(false);
 }
 
 void MainWindow::sharedAfterOpenWindow()

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -1169,7 +1169,6 @@ void MainWindow::toggleWindowState()
         QObject::connect(watcher, &QDBusPendingCallWatcher::finished, this, [=]() {
             QDBusPendingReply<QRect> reply = *watcher;
             m_availableScreenRect = reply.isValid() ? reply.value() : QRect();
-            setWindowGeometry(Settings::width(), Settings::height(), Settings::position());
             watcher->deleteLater();
         });
 

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -1401,7 +1401,7 @@ void MainWindow::sharedPreOpenWindow()
     if (Settings::pollMouse())
         toggleMousePoll(false);
     if (!Settings::rememberFullscreen())
-        setFullScreen(false);
+        KToggleFullScreenAction::setFullScreen(this, false);
 }
 
 void MainWindow::sharedAfterOpenWindow()


### PR DESCRIPTION
This series fixes https://bugs.kde.org/show_bug.cgi?id=451684, with default settings. It can still be a little buggy when enabling the setting "Remember and restore the fullscreen state".

I marked this series as a draft, as I would like to fix this issue in all cases, but I still would like some feedback on the patches.