### PR TITLE
mainwindow: Add a "Primary Screen" option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ find_package(KF6 ${KF_MIN_VERSION} REQUIRED
     Notifications
     NotifyConfig
     Parts
+    Screen
     WidgetsAddons
     WindowSystem
     StatusNotifierItem

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -60,6 +60,7 @@ target_link_libraries(yakuake
     KF6::Notifications
     KF6::NotifyConfig
     KF6::Parts
+    KF6::Screen
     KF6::WidgetsAddons
     KF6::WindowSystem
     KF6::StatusNotifierItem

--- a/app/config/windowsettings.ui
+++ b/app/config/windowsettings.ui
@@ -350,6 +350,11 @@
           </item>
           <item>
            <property name="text">
+            <string comment="@item:inlistbox">Primary screen</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
             <string comment="@item:inlistbox">Screen 1</string>
            </property>
           </item>

--- a/app/config/yakuake.kcfg
+++ b/app/config/yakuake.kcfg
@@ -7,7 +7,7 @@
   <group name="Window">
     <entry name="Screen" type="Int">
       <label context="@label">Screen to use</label>
-      <whatsthis context="@info:whatsthis">The screen on which the application window will appear. 0 is understood to be the screen the mouse pointer is on.</whatsthis>
+      <whatsthis context="@info:whatsthis">The screen on which the application window will appear. 0 is understood to be the screen the mouse pointer is on. 1 is understood to be the primary screen</whatsthis>
       <default>0</default>
     </entry>
     <entry name="Width" type="Int">

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -12,6 +12,9 @@
 
 #include <KMainWindow>
 
+#include <kscreen/config.h>
+#include <kscreen/getconfigoperation.h>
+
 #include <QTimer>
 
 class FirstRunDialog;
@@ -147,6 +150,8 @@ private Q_SLOTS:
     void firstRunDialogFinished();
     void firstRunDialogOk();
 
+    void storeKScreenConfig(KScreen::ConfigOperation *op);
+
 private:
     void setupActions();
 
@@ -211,6 +216,8 @@ private:
 
     bool m_isX11;
     bool m_isWayland;
+
+    KScreen::ConfigPtr m_kscreenConfig = nullptr;
 
 #if HAVE_KWAYLAND
     void initWayland();


### PR DESCRIPTION
The screen number of the selected primary screen can change between sessions.
The screen numbers can also vary, especially with laptops moving from a docking station to another.

To have a more stable behavior, add the option to always drop down on the selected Primary screen (a.k.a the screen with highest priority).

This adds a dependency on libkscreen to retrieve the outputs priority values.

A possible issue is that the current configs will be wrong as anything higher than 0 will be shifted (1: screen 1 -> Primary screen, 2: screen 2 -> screen 1, ...). Let me know if that is an issue that needs to be worked out.