### PR TITLE
Fix bug where window opens on left of multi-monitor setup

### DIFF
--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -1200,11 +1200,10 @@ void MainWindow::toggleWindowState()
         QObject::connect(watcher, &QDBusPendingCallWatcher::finished, this, [=, this]() {
             QDBusPendingReply<QRect> reply = *watcher;
             m_availableScreenRect = reply.isValid() ? reply.value() : QRect();
+            _toggleWindowState();
             setWindowGeometry(Settings::width(), Settings::height(), Settings::position());
             watcher->deleteLater();
         });
-
-        _toggleWindowState();
     } else {
         _toggleWindowState();
     }


### PR DESCRIPTION
**Bug:**  
On multi-monitor setup, move mouse so that another monitor is focused, open yakuake with shortcut, and observe that yakuake always initially opens on left edge of screen, ignoring user settings. Subsequent shortcut presses on the same monitor open normally.

**Issues:**  
 - https://bugs.kde.org/show_bug.cgi?id=504138
 - https://bugs.kde.org/show_bug.cgi?id=510476

---

This bug fix was originally authored by [Max](https://bugs.kde.org/show_bug.cgi?id=504138#c9)